### PR TITLE
添加“删除弃用api”的配置

### DIFF
--- a/HackathonBot/config.py
+++ b/HackathonBot/config.py
@@ -524,6 +524,45 @@ configs = [
 
         # 是否为黑客松任务
         'hackathon': False,
+    },{
+        # 任务名称，起标识作用
+        'issue_name': "【Docathon】删除被弃用的API",
+
+        # 开始时间，只会统计开始时间之后的PR(注意时间中的字母T和Z不能缺少)
+        'start_time' : '2025-04-07T00:00:00Z',
+
+        # issue页面 url 地址, 注意结尾不要有斜杠
+        'issue_url': 'https://api.github.com/repos/PaddlePaddle/docs/issues/7238',
+
+        # 监控的仓库列表
+        'repo_urls': ['https://api.github.com/repos/PaddlePaddle/docs/pulls'],
+
+        # 最大的任务ID
+        'max_task_id' : 19,
+
+        # 忽略不处理的题号，这部分留给人工处理
+        'un_handle_tasks' : [],
+
+        # 已删除的赛题
+        'removed_tasks' : [],
+
+        # 赛道名
+        'type_names' : ["删除被弃用的API"],
+
+        # 每个赛题所属的赛道，每个赛道是一个数组
+        'task_types' : [['1-19']],
+
+        # 该issue相关PR的前缀，用来标识PR是否属于该issue
+        'pr_prefix' : "Delete Deprecated API Doc",
+
+        # PR、状态等信息所在的列
+        'pr_col': 3,
+        
+        # 是否展示看板信息
+        'board': True,
+
+        # 是否为黑客松任务
+        'hackathon': False,
     }
 ]
 


### PR DESCRIPTION
添加“删除弃用api”的配置：
issue: https://github.com/PaddlePaddle/docs/issues/7238
任务最大值：19
非Hackathon任务

@luotao1 