### PR TITLE
精度问题推全 issue 区 max_task_id + 4

### DIFF
--- a/HackathonBot/config.py
+++ b/HackathonBot/config.py
@@ -231,7 +231,7 @@ configs = [
         'repo_urls': ['https://api.github.com/repos/PaddlePaddle/Paddle/pulls','https://api.github.com/repos/PFCCLab/PaddleAPITest/pulls'],
 
         # 最大的任务ID
-        'max_task_id' : 183,
+        'max_task_id' : 187,
 
         # 忽略不处理的题号，这部分留给人工处理
         'un_handle_tasks' : [],
@@ -243,7 +243,7 @@ configs = [
         'type_names' : ["精度问题修复"],
 
         # 每个赛题所属的赛道，每个赛道是一个数组
-        'task_types' : [['1-183']],
+        'task_types' : [['1-187']],
 
         # 该issue相关PR的前缀，用来标识PR是否属于该issue
         'pr_prefix' : "Accuracy diff No.",


### PR DESCRIPTION
精度问题推全 https://api.github.com/repos/PaddlePaddle/Paddle/issues/72667:L234  max_task_id + 4

主要关于 paddle.ldexp 和 paddle.ldexp_ 的精度问题 https://github.com/PFCCLab/PaddleAPITest/pull/392

新增 4 行数据在issue区 分别是：

序号 | API | kernel类别 | 报名人/状态/PR
-- | -- | -- | --
184 | paddle.ldexp | GPU | 在float16，output dtype类型不同，暂不要报名
185 | paddle.ldexp | CPU | 在float16，output dtype类型不同，暂不要报名
186 | paddle.ldexp_ | GPU | 在float16，output dtype类型不同，暂不要报名
187 | paddle.ldexp_ | CPU | 在float16，output dtype类型不同，暂不要报名


